### PR TITLE
make Sum preserve the internal state

### DIFF
--- a/blake2b.go
+++ b/blake2b.go
@@ -150,7 +150,9 @@ func (d *digest) Reset() {
 
 func (d *digest) Sum(buf []byte) []byte {
 	digest := make([]byte, d.Size())
-	C.blake2b_final(d.state, (*C.uint8_t)(&digest[0]), C.uint8_t(d.Size()))
+	// Make a copy of d.state so that caller can keep writing and summing.
+	s := *d.state
+	C.blake2b_final(&s, (*C.uint8_t)(&digest[0]), C.uint8_t(d.Size()))
 	return append(buf, digest...)
 }
 

--- a/blake2b.go
+++ b/blake2b.go
@@ -15,7 +15,7 @@ import (
 )
 
 type digest struct {
-	state      *C.blake2b_state
+	state      C.blake2b_state
 	key        []byte
 	param      C.blake2b_param
 	isLastNode bool
@@ -135,12 +135,11 @@ func (d *digest) Size() int {
 }
 
 func (d *digest) Reset() {
-	d.state = new(C.blake2b_state)
 	var key unsafe.Pointer
 	if d.param.key_length > 0 {
 		key = unsafe.Pointer(&d.key[0])
 	}
-	if C.blake2b_init_parametrized(d.state, &d.param, key) < 0 {
+	if C.blake2b_init_parametrized(&d.state, &d.param, key) < 0 {
 		panic("blake2: unable to reset")
 	}
 	if d.isLastNode {
@@ -151,14 +150,14 @@ func (d *digest) Reset() {
 func (d *digest) Sum(buf []byte) []byte {
 	digest := make([]byte, d.Size())
 	// Make a copy of d.state so that caller can keep writing and summing.
-	s := *d.state
+	s := d.state
 	C.blake2b_final(&s, (*C.uint8_t)(&digest[0]), C.uint8_t(d.Size()))
 	return append(buf, digest...)
 }
 
 func (d *digest) Write(buf []byte) (int, error) {
 	if len(buf) > 0 {
-		C.blake2b_update(d.state, (*C.uint8_t)(&buf[0]), C.uint64_t(len(buf)))
+		C.blake2b_update(&d.state, (*C.uint8_t)(&buf[0]), C.uint64_t(len(buf)))
 	}
 	return len(buf), nil
 }

--- a/blake2b_test.go
+++ b/blake2b_test.go
@@ -554,6 +554,18 @@ func TestSumState(t *testing.T) {
 	}
 }
 
+func TestReset(t *testing.T) {
+	h := New(nil)
+	h.Write([]byte("foo"))
+	s1 := h.Sum(nil)
+	h.Reset()
+	h.Write([]byte("foo"))
+	s2 := h.Sum(nil)
+	if !bytes.Equal(s1, s2) {
+		t.Error("sum values unequal after reset")
+	}
+}
+
 func ExampleNew() {
 	h := New(nil)
 	h.Write([]byte("one two three"))

--- a/blake2b_test.go
+++ b/blake2b_test.go
@@ -1,6 +1,7 @@
 package blake2
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 )
@@ -539,6 +540,17 @@ func TestBlake2B(t *testing.T) {
 		if actual != expected {
 			t.Errorf("bad hash (%d): input=%X, expected=%X, actual=%s", len, input, expected, actual)
 		}
+	}
+}
+
+func TestSumState(t *testing.T) {
+	h := New(nil)
+	// Sum should not modify its internal state; so
+	// it should return the same value twice in a row.
+	s1 := h.Sum(nil)
+	s2 := h.Sum(nil)
+	if !bytes.Equal(s1, s2) {
+		t.Error("consecutive sum values unequal")
 	}
 }
 


### PR DESCRIPTION
Fixes #2.

No measurable change in speed.

Keeping the blake2b_state inline inside the digest struct instead of as a pointer would get rid of an allocation bringing it back down to 4 per op. I can follow up with that in another PR if you want (or do it here).

```
benchmark              old ns/op     new ns/op     delta
BenchmarkBlake2B-4     1754047       1727184       -1.53%

benchmark              old MB/s     new MB/s     speedup
BenchmarkBlake2B-4     597.80       607.10       1.02x

benchmark              old allocs     new allocs     delta
BenchmarkBlake2B-4     4              5              +25.00%

benchmark              old bytes     new bytes     delta
BenchmarkBlake2B-4     625           1009          +61.44%
```