### PR TITLE
Compare blake2b with CRC32 and CRC64

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"hash"
+	"hash/crc32"
+	"hash/crc64"
 	"testing"
 )
 
@@ -39,4 +41,17 @@ func BenchmarkSHA256(b *testing.B) {
 
 func BenchmarkSHA512(b *testing.B) {
 	benchmarkHash(b, sha512.New)
+}
+
+func BenchmarkCRC32(b *testing.B) {
+	benchmarkHash(b, func() hash.Hash {
+		return crc32.NewIEEE()
+	})
+}
+
+func BenchmarkCRC64(b *testing.B) {
+	table := crc64.MakeTable(crc64.ISO)
+	benchmarkHash(b, func() hash.Hash {
+		return crc64.New(table)
+	})
 }


### PR DESCRIPTION
I was curious how blake2b would compare to the supposedly fast CRC32 and CRC64 (non-cryptographic) hash functions. It turns out blake2b is even faster (which I certainly hadn't expected when comparing a cryptographic with a non-cryptographic hash). It may also be that the CRC implementations of Go aren't very well optimized. Anyway, you are free to add this benchmark.

```
$ go test -bench=. github.com/codahale/blake2
PASS
BenchmarkBlake2B        1000       1979993 ns/op     529.59 MB/s
BenchmarkMD5        1000       1502548 ns/op     697.87 MB/s
BenchmarkSHA1       1000       2269590 ns/op     462.01 MB/s
BenchmarkSHA256      500       5681939 ns/op     184.55 MB/s
BenchmarkSHA512      500       3669713 ns/op     285.74 MB/s
BenchmarkCRC32       500       3074694 ns/op     341.03 MB/s
BenchmarkCRC64       500       3092819 ns/op     339.04 MB/s
ok      github.com/codahale/blake2  15.697s
```

This was tested on an Intel i7-2600 (according to `/proc/cpuinfo`).
